### PR TITLE
Fix issue 6 and 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [2.0.1] - 06-11-2025
+
+### Fixed
+
+- Fixed [#6](https://github.com/Tools4everBV/HelloID-Conn-Prov-Target-StudyTube/issues/6): Added null checks for empty API responses during pagination in resource scripts. When the API returns an empty response (e.g., on the last page when the total record count is a multiple of the page size), the encoding conversion would fail. This has been resolved by checking for null or empty responses before attempting the encoding conversion in:
+  - `resources\Users\resources.ps1`
+  - `resources\teams\retrieve\resources.ps1`
+
+- Fixed [#9](https://github.com/Tools4everBV/HelloID-Conn-Prov-Target-StudyTube/issues/9): Re-added the missing `$jsonBody` variable definition in `create.ps1`. The line `$jsonBody = $actionContext.Data | ConvertTo-Json -Depth 10` was accidentally removed in a previous update, causing the `$splatCreateUserParams` object to be incomplete.
+
 ## [2.0.0] - 20-09-2024
 
 ### Added

--- a/create.ps1
+++ b/create.ps1
@@ -100,6 +100,7 @@ try {
     if (-not($actionContext.DryRun -eq $true)) {
         switch ($action) {
             'CreateAccount' {
+                $jsonBody = $actionContext.Data | ConvertTo-Json -Depth 10
                 Write-Information 'Creating and correlating StudyTube account'
                 $splatCreateUserParams = @{
                     Uri         = "$($actionContext.Configuration.BaseUrl)/api/v2/users"

--- a/create.ps1
+++ b/create.ps1
@@ -100,8 +100,8 @@ try {
     if (-not($actionContext.DryRun -eq $true)) {
         switch ($action) {
             'CreateAccount' {
-                $jsonBody = $actionContext.Data | ConvertTo-Json -Depth 10
                 Write-Information 'Creating and correlating StudyTube account'
+                $jsonBody = $actionContext.Data | ConvertTo-Json -Depth 10
                 $splatCreateUserParams = @{
                     Uri         = "$($actionContext.Configuration.BaseUrl)/api/v2/users"
                     Method      = 'POST'

--- a/delete.ps1
+++ b/delete.ps1
@@ -51,10 +51,6 @@ try {
         throw 'The account reference could not be found'
     }
 
-    Write-Information 'Setting authorization header'
-    $headers = [System.Collections.Generic.Dictionary[string, string]]::new()
-    $headers.Add('Authorization', "Bearer $($tokenResponse.access_token)")
-
     Write-Information 'Retrieving authorization token'
     $headers = [System.Collections.Generic.Dictionary[string, string]]::new()
     $headers.Add("Content-Type", "application/x-www-form-urlencoded")
@@ -65,6 +61,10 @@ try {
         scope         = 'read write'
     }
     $tokenResponse = Invoke-RestMethod -Uri "$($actionContext.Configuration.TokenUrl)/gateway/oauth/token" -Method 'POST' -Headers $headers -Body $tokenBody -verbose:$false
+
+    Write-Information 'Setting authorization header'
+    $headers = [System.Collections.Generic.Dictionary[string, string]]::new()
+    $headers.Add('Authorization', "Bearer $($tokenResponse.access_token)")
 
     # Add a message and the result of each of the validations showing what will happen during enforcement
     if ($actionContext.DryRun -eq $true) {

--- a/resources/Users/resources.ps1
+++ b/resources/Users/resources.ps1
@@ -23,7 +23,8 @@ function Resolve-StudyTubeError {
         }
         if (-not [string]::IsNullOrEmpty($ErrorObject.ErrorDetails.Message)) {
             $httpErrorObj.ErrorDetails = $ErrorObject.ErrorDetails.Message
-        } elseif ($ErrorObject.Exception.GetType().FullName -eq 'System.Net.WebException') {
+        }
+        elseif ($ErrorObject.Exception.GetType().FullName -eq 'System.Net.WebException') {
             if ($null -ne $ErrorObject.Exception.Response) {
                 $streamReaderResponse = [System.IO.StreamReader]::new($ErrorObject.Exception.Response.GetResponseStream()).ReadToEnd()
                 if (-not [string]::IsNullOrEmpty($streamReaderResponse)) {
@@ -37,7 +38,8 @@ function Resolve-StudyTubeError {
             if ($errorDetailsObject.error_description) {
                 $httpErrorObj.FriendlyMessage = $errorDetailsObject.error_description
             }
-        } catch {
+        }
+        catch {
             $httpErrorObj.FriendlyMessage = $httpErrorObj.ErrorDetails
         }
         Write-Output $httpErrorObj
@@ -75,11 +77,18 @@ try {
         try {
             $rawUsersResult = Invoke-RestMethod @splatGetUserParams -Verbose:$false
             $isoEncoding = [System.Text.Encoding]::GetEncoding('ISO-8859-1')
-            $partialResultUsers = [System.Text.Encoding]::UTF8.GetString($isoEncoding.GetBytes(($rawUsersResult | ConvertTo-Json -Depth 10))) | ConvertFrom-json
-        } catch {
+            if ($null -eq $rawUsersResult -or ($rawUsersResult -is [string] -and [string]::IsNullOrWhiteSpace($rawUsersResult))) {
+                $partialResultUsers = @()
+            }
+            else {
+                $partialResultUsers = [System.Text.Encoding]::UTF8.GetString($isoEncoding.GetBytes(($rawUsersResult | ConvertTo-Json -Depth 10))) | ConvertFrom-json
+            }
+        }
+        catch {
             if ( $_.Exception.StatusCode -eq 429) {
                 throw "TooManyRequests: Hit the rating limit. Please try using a higher ResourcePageSize configuration. The current is [$($actionContext.Configuration.ResourcePageSize)]. The API maximum is 1000."
-            } else {
+            }
+            else {
                 throw
             }
         }
@@ -95,7 +104,8 @@ try {
     Write-Information "Export [$($returnUsers.Count)] users to CSV: [$($actionContext.Configuration.UserCsvExportFileAndPath)]"
     $returnUsers | Select-Object id, full_name, uid, employee_number, email | Export-Csv -Path "$($actionContext.Configuration.UserCsvExportFileAndPath)" -NoTypeInformation -Force
     $outputContext.Success = $true
-} catch {
+}
+catch {
     $outputContext.Success = $false
     $ex = $PSItem
     if ($($ex.Exception.GetType().FullName -eq 'Microsoft.PowerShell.Commands.HttpResponseException') -or
@@ -103,7 +113,8 @@ try {
         $errorObj = Resolve-StudyTubeError -ErrorObject $ex
         $auditMessage = "Could not create StudyTube users resource CSV file. Error: $($errorObj.FriendlyMessage)"
         Write-Warning "Error at Line '$($errorObj.ScriptLineNumber)': $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
-    } else {
+    }
+    else {
         $auditMessage = "Could not create StudyTube users resource CSV file. Error: $($ex.Exception.Message)"
         Write-Warning "Error at Line '$($ex.InvocationInfo.ScriptLineNumber)': $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
     }

--- a/resources/teams/retrieve/resources.ps1
+++ b/resources/teams/retrieve/resources.ps1
@@ -75,7 +75,12 @@ try {
         try {
             $rawTeamsContent = Invoke-RestMethod @splatGetUserParams -Verbose:$false
             $isoEncoding = [System.Text.Encoding]::GetEncoding('ISO-8859-1')
-            $partialResultTeams = [System.Text.Encoding]::UTF8.GetString($isoEncoding.GetBytes(($rawTeamsContent | ConvertTo-Json -Depth 10))) | ConvertFrom-json
+            if ($null -eq $rawTeamsContent -or ($rawTeamsContent -is [string] -and [string]::IsNullOrWhiteSpace($rawTeamsContent))) {
+                $partialResultTeams = @()
+            }
+            else {
+                $partialResultTeams = [System.Text.Encoding]::UTF8.GetString($isoEncoding.GetBytes(($rawTeamsContent | ConvertTo-Json -Depth 10))) | ConvertFrom-json
+            }
         } catch {
             if ( $_.Exception.StatusCode -eq 429) {
                 throw "TooManyRequests: Hit the rating limit. Please try using a higher ResourcePageSize configuration. The current is [$($actionContext.Configuration.ResourcePageSize)]. The API maximum is 1000."


### PR DESCRIPTION
## [2.0.1] - 06-11-2025

### Fixed

- Fixed [#6](https://github.com/Tools4everBV/HelloID-Conn-Prov-Target-StudyTube/issues/6): Added null checks for empty API responses during pagination in resource scripts. When the API returns an empty response (e.g., on the last page when the total record count is a multiple of the page size), the encoding conversion would fail. This has been resolved by checking for null or empty responses before attempting the encoding conversion in:
  - `resources\Users\resources.ps1`
  - `resources\teams\retrieve\resources.ps1`

- Fixed [#9](https://github.com/Tools4everBV/HelloID-Conn-Prov-Target-StudyTube/issues/9): Re-added the missing `$jsonBody` variable definition in `create.ps1`. The line `$jsonBody = $actionContext.Data | ConvertTo-Json -Depth 10` was accidentally removed in a previous update, causing the `$splatCreateUserParams` object to be incomplete.